### PR TITLE
フォント名変更で、Name ID = 16 の値（Typographic Family name）も書き換える

### DIFF
--- a/Diva.FontSubsetting/Diva.FontSubsetting.csproj
+++ b/Diva.FontSubsetting/Diva.FontSubsetting.csproj
@@ -7,7 +7,7 @@
         <RepositoryUrl>https://github.com/diva-osaka/Diva.FontSubsetting</RepositoryUrl>
         <DebugType>embedded</DebugType>
         <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-        <Version>1.0.6</Version>
+        <Version>1.0.7</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Diva.FontSubsetting/FontSubsetter.cs
+++ b/Diva.FontSubsetting/FontSubsetter.cs
@@ -121,7 +121,6 @@ public static class FontSubsetter
             var originalEntry = originalNameTable.nameEntry(i);
             var nameId = originalEntry.nameId();
 
-            if (nameId != NameId.FontFamilyName.value())
             // Name ID = 1 (Font Family name) と Name ID = 16 (Typographic Family name) を書き換える
             if (nameId != NameId.FontFamilyName.value() && nameId != NameId.PreferredFamily.value())
                 continue;

--- a/Diva.FontSubsetting/FontSubsetter.cs
+++ b/Diva.FontSubsetting/FontSubsetter.cs
@@ -122,6 +122,8 @@ public static class FontSubsetter
             var nameId = originalEntry.nameId();
 
             if (nameId != NameId.FontFamilyName.value())
+            // Name ID = 1 (Font Family name) と Name ID = 16 (Typographic Family name) を書き換える
+            if (nameId != NameId.FontFamilyName.value() && nameId != NameId.PreferredFamily.value())
                 continue;
 
             // 深追いはしていないが、ICU4JはIKVMで変換したときにうまく内部リソースデータを取得できない&ビルドに時間が掛かる

--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ List<byte[]> subsetFonts = FontSubsetter.SubsetFonts(fontBytes, "こんにちは
 ## 制限
 
 * TTF 形式のみ（バリアブルフォント未対応）
-* サブセット化したフォントのファミリー名を「{元のファミリー名}+{suffix}」に変更するが、[Name ID](https://learn.microsoft.com/en-us/typography/opentype/spec/name#name-ids) = 1 の値を変更する（Name ID = 16 の場合は未対応）。
+
+## 仕様
+
+* サブセット化したフォントのファミリー名を「{元のファミリー名}+{suffix}」に変更する。[Name ID](https://learn.microsoft.com/en-us/typography/opentype/spec/name#name-ids) = 1, 16 の値を変更する。


### PR DESCRIPTION
This pull request includes updates to the font subsetting logic, documentation, and project version. The most important changes involve enhancing font family name handling, updating the project to a new version, and improving the README to reflect the updated behavior.

### Font subsetting logic updates:
* [`Diva.FontSubsetting/FontSubsetter.cs`](diffhunk://#diff-71874d4e696e9f5c03257506aa772f9e0dc2063acb6fc3c00e33be72a8fea1c4R125-R126): Updated the logic to modify both `Name ID = 1` (Font Family Name) and `Name ID = 16` (Typographic Family Name) during font subsetting, ensuring broader support for font naming conventions.

### Documentation improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R21): Updated the documentation to clarify that both `Name ID = 1` and `Name ID = 16` are now modified when subsetting fonts, replacing the previous limitation where only `Name ID = 1` was addressed.

### Project version update:
* [`Diva.FontSubsetting/Diva.FontSubsetting.csproj`](diffhunk://#diff-209043d2487df33a363c0fb5a4163b100518e672cba69ddbe04566175bc6adb3L10-R10): Incremented the project version from `1.0.6` to `1.0.7` to reflect the new changes and improvements.